### PR TITLE
docs: adopt Governance Charter + ADR-0002

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adr-proposal.yml
@@ -1,0 +1,3 @@
+name: "🏛️ ADR Proposal"
+description: "Propose an Architecture Decision Record for a significant change."
+(…rest of ADR proposal template…)

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,3 @@
+name: "🐞 Bug Report"
+description: "Create a report to help us improve."
+(…rest of bug template…)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### Linked Issue
+Closes #
+(…rest of template…)

--- a/docs/ADR-0002-governance-charter.md
+++ b/docs/ADR-0002-governance-charter.md
@@ -1,0 +1,2 @@
+# ADR-0002: Adopt Official Governance Charter
+(…ADR-0002 content from the draft…)

--- a/docs/GOVERNANCE_CHARTER.md
+++ b/docs/GOVERNANCE_CHARTER.md
@@ -1,0 +1,2 @@
+# Paper Plane Roblox Governance Charter
+(…full content from the draft you pasted earlier…)


### PR DESCRIPTION
- Introduces `docs/GOVERNANCE_CHARTER.md` (roles, RACI, PR gates, Roblox guardrails, release quality bar).
- Adds ADR-0002 to formalize adoption.
- Adds PR + Issue templates (bug, ADR proposal).
- Appends README snippet linking to governance docs.

Expectation: Guardian CI runs; Chronicle will seal on merge.
